### PR TITLE
Create det.php from index.php and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ In the index.php file, be sure to modify the log location to a suitable path for
 Typically these files are placed in your root redcap folder as:
 /plugins/autonotify/index.php
 /plugins/autonotify/common.php
+/plugins/autonotify/det.php
 
 They should be 'outside' your redcap_vx.y.z folders (as siblings).
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ In the index.php file, be sure to modify the log location to a suitable path for
 
 ## Installation ##
 Typically these files are placed in your root redcap folder as:
-/plugins/autonotify/index.php
-/plugins/autonotify/common.php
-/plugins/autonotify/det.php
+
+    /plugins/autonotify/index.php
+    /plugins/autonotify/common.php
+    /plugins/autonotify/det.php
 
 They should be 'outside' your redcap_vx.y.z folders (as siblings).
 

--- a/common.php
+++ b/common.php
@@ -234,6 +234,9 @@ class AutoNotify {
         // Remove query string from DET url
         $url = preg_replace('/\?.*/', '', $url);
 
+        // Replace index.php with det.php
+        $url = preg_replace("/index.php/", "det.php", $url);
+
         return $url;
     }
 

--- a/det.php
+++ b/det.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ *
+ * This plugin is designed to help create automatic email notifications when sensitive
+ * responses are received from a survey.
+ *
+ * As of 2016-03-01 Autonotify was modified to store the configuration in the log instead of using the DET query string.
+ * This was done to alleviate issues around maximum query string length.  The new version offers the ability to upgrade existing
+ * autonitfy configurations on first use.
+ *
+ * It must be used in conjunction with a data entry trigger to function in real-time.
+ * The settings for each project are stored as an encoded variable (an) in the query string of the DET.
+ *
+ *
+ * 
+ * Andrew Martin, Stanford University, 2016
+ *
+**/
+error_reporting(E_ALL);
+
+
+
+// MANUAL LOG FILE
+$log_file = "/var/log/redcap/autonotify";
+
+// MANUAL OVERRIDE OF HTTPS - Add your url domain to this array if you want to only use http
+$http_only = array('stanford.edu');
+
+// OPTIONAL SPECIAL LOG FILE FOR THIS PLUGIN (OTHERWISE WILL WRITE TO REDCAP TEMP)
+//$log_file = "/var/log/redcap/autonotify.log";
+
+// ////////////// DONT EDIT BELOW HERE //////////////
+
+$action = '';	// Script action
+##### RUNNING AS DET - PART 1 #####
+if ( $_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['redcap_url']) ) {
+    $action = 'det';
+    define('NOAUTH',true);	// Turn off Authentication - running on server
+    $_GET['pid'] = $_POST['project_id'];	// Set the pid from POST so context is Project rather than Global
+}
+
+// Include required files
+require_once "../../redcap_connect.php";
+require_once "common.php";
+require_once "det.php";
+
+// If a log file hasn't been set, then let's default to the REDCap temp folder
+if (!isset($log_file)) {
+    $log_file = APP_PATH_TEMP . "autonotify_plugin.log";
+}
+
+// Create an AutoNotify Object
+$an = new AutoNotify($project_id);
+//error_log("Here");
+
+logIt("Starting AutoNotify on project $project_id");
+logIt("DET URL: " . $an->getDetUrl(), "DEBUG");
+
+
+##### RUNNING AS DET - PART 2 #####
+if ($action == 'det') {
+    // Execute AutoNotify script if called from DET trigger
+    $an->loadDetPost();
+    $an->loadConfig();
+    $an->execute();
+    exit;
+}

--- a/det.php
+++ b/det.php
@@ -13,7 +13,7 @@
  * The settings for each project are stored as an encoded variable (an) in the query string of the DET.
  *
  *
- * 
+ *
  * Andrew Martin, Stanford University, 2016
  *
 **/
@@ -22,7 +22,7 @@ error_reporting(E_ALL);
 
 
 // MANUAL LOG FILE
-$log_file = "/var/log/redcap/autonotify";
+// $log_file = "/Users/andy123/Documents/local REDCap server/redcap/temp/autonotify.log";
 
 // MANUAL OVERRIDE OF HTTPS - Add your url domain to this array if you want to only use http
 $http_only = array('stanford.edu');
@@ -30,20 +30,20 @@ $http_only = array('stanford.edu');
 // OPTIONAL SPECIAL LOG FILE FOR THIS PLUGIN (OTHERWISE WILL WRITE TO REDCAP TEMP)
 //$log_file = "/var/log/redcap/autonotify.log";
 
-// ////////////// DONT EDIT BELOW HERE //////////////
 
-$action = '';	// Script action
+////////////// DONT EDIT BELOW HERE //////////////
+
+$action = '';   // Script action
 ##### RUNNING AS DET - PART 1 #####
 if ( $_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['redcap_url']) ) {
     $action = 'det';
-    define('NOAUTH',true);	// Turn off Authentication - running on server
-    $_GET['pid'] = $_POST['project_id'];	// Set the pid from POST so context is Project rather than Global
+    define('NOAUTH',true);  // Turn off Authentication - running on server
+    $_GET['pid'] = $_POST['project_id'];    // Set the pid from POST so context is Project rather than Global
 }
 
 // Include required files
 require_once "../../redcap_connect.php";
 require_once "common.php";
-require_once "det.php";
 
 // If a log file hasn't been set, then let's default to the REDCap temp folder
 if (!isset($log_file)) {
@@ -55,7 +55,7 @@ $an = new AutoNotify($project_id);
 //error_log("Here");
 
 logIt("Starting AutoNotify on project $project_id");
-logIt("DET URL: " . $an->getDetUrl(), "DEBUG");
+//logIt("DET URL: " . $an->getDetUrl(), "DEBUG");
 
 
 ##### RUNNING AS DET - PART 2 #####


### PR DESCRIPTION
Andy,

In this pull request I'm creating a separate det.php for the portion of the code that calls the data event trigger.  This allows us to put that one portion of code outside of Shibboleth instead of exposing all of autonotify's index.php. det.php is no more than a copy of the first 69 lines of the index.php.

I also updated the README.md to add det.php to the installation procedure and fix some formatting.  

It would be great if could merge this into your repo.

Regards,
Philip
