### PR TITLE
Add patch to common.php to allow for the configuration to be saved

### DIFF
--- a/common.php
+++ b/common.php
@@ -84,7 +84,7 @@ class AutoNotify {
         $sql = "SELECT l.sql_log, l.ts
 			FROM redcap_log_event l WHERE
 		 		l.project_id = " . intval($this->project_id) . "
-			AND l.page = 'PLUGIN'
+			AND (l.page = 'PLUGIN' OR l.page LIKE '%autonotify/index.php%')
 			AND l.description = '" . AutoNotify::PluginName . " Config'
 			ORDER BY ts DESC LIMIT 1";
         $q = db_query($sql);


### PR DESCRIPTION
Hi Andy,

Please review this PR. I applied [this](https://community.projectredcap.org/questions/30989/autonotify-redcap-v80-cant-save.html) suggested patch to the file `common.php`. The patch fixes the issue that prevented the configuration of **autonotify** to be saved in recent versions of redcap (v8.0.0 and onwards).

Thank you.